### PR TITLE
OneBot消息体处理插件

### DIFF
--- a/app/plugins/bs_plugin_message_filter/README.md
+++ b/app/plugins/bs_plugin_message_filter/README.md
@@ -1,0 +1,97 @@
+# bs_plugin_message_filter
+基于BotShepherd的消息过滤插件
+
+## 框架介绍
+
+[🐑 BotShepherd](https://github.com/syuan326/BotShepherd)
+BotShepherd 是一个基于OneBot v11协议WebSocket代理和管理系统，统一管理和协调多个Bot实例，实现一对多的连接管理、消息统计、跨框架黑名单、全框架分群组功能开关和别名防冲突。
+
+人话：一个账号只需要一个ws连接接入本系统，就可以自由的连接到下游框架。本系统可以方便的统计单个账号消息量，管理黑名单，进行指令转化等。你不再需要为每个账号创建一个Nonebot或配置 账号数量x框架数量 个ws连接
+
+## 灵光一现
+
+**BotShepherd**既然是QQ与Bot的桥梁，那么就可以在**BotShepherd**拦截OneBot消息体，修改然后放行，那么这里面就有大文章了（bushi）
+
+## 刨坑（咕咕咕）
+
+除了更改消息体，我们还可以从中提取text类型，经过渲染之后可以变成`旮旯给木`的图片
+
+## 使用教程
+
+在`框架根目录`下执行
+
+```bash
+git clone https://github.com/syuan326/bs_plugin_message_filter.git ./app/plugins/bs_plugin_message_filterter
+```
+
+运行一次框架后会得到一个原始json文件，可参考下一章节去配置
+
+```json
+{
+  "enabled": true
+}
+```
+
+## Json结构
+
+```json
+{
+  "enabled": true, 
+
+  "text": [
+    {
+      "mode": "replace",
+      "args": [
+        ["原词", "新词"],
+        ["坏话", "***"]
+      ]
+    },
+    {
+      "mode": "prepend",
+      "args": "【前缀】"
+    },
+    {
+      "mode": "append",
+      "args": "【后缀】"
+    }
+  ],
+
+  "image": [
+    {
+      "mode": "set_summary",
+      "args": "这是一张图片"
+    },
+    {
+      "mode": "append_summary",
+      "args": "（已处理）"
+    },
+    {
+      "mode": "replace_file",
+      "args": "file:///C:/xxx/xxx.png"
+    },
+    {
+      "mode": "remove"
+    }
+  ]
+}
+```
+
+enabled: 插件启停开关
+第一层是OneBot消息类型
+第二层是具体操作
+第三层是操作参数
+
+---
+
+## 测试
+
+![111](https://gitee.com/Elvin-Apocalys/pic-bed/raw/master/git_img/gitpng.png)
+
+## 增减操作或获取OneBot消息体另谋他路
+
+在**plugin.py**第192行到第200行间，`segments`变量是捕获到的原始消息体，`new_segments`是处理过的消息体
+
+## 鸣谢
+
+- [小维](https://github.com/Loping151) - xw跑路
+- [小维的框架](https://github.com/syuan326/BotShepherd) - 让Bot管理变得简单而强大 🐑✨

--- a/app/plugins/bs_plugin_message_filter/__init__.py
+++ b/app/plugins/bs_plugin_message_filter/__init__.py
@@ -1,0 +1,82 @@
+"""
+消息段规则处理插件导出入口
+
+- 主要逻辑在同目录的 `plugin.py` 中
+- 导入本包时，会自动把发送消息的过滤流程挂接上规则处理
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from app.onebotv11.models import Event
+from app.server.filter_manager import FilterManager
+
+from .plugin import RULES_JSON_PATH, apply_rule, apply_rules_to_message, logger
+
+
+async def _patched_filter_send_message(
+    self: FilterManager,
+    event: Event,
+    message_data: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """
+    包装原有的发送过滤逻辑，在其之后再套一层消息段规则处理。
+
+    - 只对机器人发送的消息生效（通过 self_id == user_id 判断）
+    - 如果原过滤器返回 None（表示拦截），则不再处理
+    """
+    # 保留原有 FilterManager 的发送过滤逻辑
+    original = _patched_filter_send_message.__original_filter  # type: ignore[attr-defined]
+    result = await original(self, event, message_data)
+    if not result:
+        return result
+
+    try:
+        params = result.get("params") or {}
+        segments = params.get("message")
+        if not isinstance(segments, list):
+            return result
+
+        new_segments = apply_rules_to_message(
+            segments,
+            self_id=str(getattr(event, "self_id", "")),
+            user_id=str(getattr(event, "user_id", "")),
+            is_bot_message=None,  # 走内部 self_id == user_id 判断
+            debug=False,
+        )
+        params["message"] = new_segments
+        result["params"] = params
+        return result
+    except Exception as e:  # 防御性处理，任何异常都不影响主流程
+        logger.error(
+            "[bs_plugin_message_filter] 发送消息规则处理失败: %s", e, exc_info=True
+        )
+        return result
+
+
+def _monkey_patch_filter_manager() -> None:
+    """在导入插件时，对 FilterManager 进行一次性打补丁。"""
+    if getattr(FilterManager, "_bs_message_rules_patched", False):
+        return
+
+    # 记录原始实现到包装函数属性上，方便内部调用
+    setattr(
+        _patched_filter_send_message,
+        "__original_filter",
+        FilterManager.filter_send_message,
+    )
+    FilterManager.filter_send_message = _patched_filter_send_message  # type: ignore[assignment]
+    setattr(FilterManager, "_bs_message_rules_patched", True)
+    logger.info("[bs_plugin_message_filter] 已挂接")
+
+
+# 模块导入时立即打补丁
+_monkey_patch_filter_manager()
+
+
+__all__ = [
+    "apply_rules_to_message",
+    "apply_rule",
+    "RULES_JSON_PATH",
+]

--- a/app/plugins/bs_plugin_message_filter/plugin.py
+++ b/app/plugins/bs_plugin_message_filter/plugin.py
@@ -1,0 +1,239 @@
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional, Union
+
+from app.onebotv11.models import MessageSegment
+
+logger = logging.getLogger("BotShepherd.Message")
+
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
+RULES_JSON_PATH = os.path.join(BASE_DIR, "rules.json")
+
+if not os.path.exists(RULES_JSON_PATH):
+    # 默认创建一个禁用状态且无规则的配置
+    with open(RULES_JSON_PATH, "w", encoding="utf-8") as f:
+        json.dump({"enabled": False}, f, ensure_ascii=False, indent=2)
+    logger.info("[bs_plugin_message_filter] 规则文件已创建: %s", RULES_JSON_PATH)
+
+
+def _load_raw_config() -> Dict[str, Any]:
+    """加载原始配置（包含 enabled 等开关和规则内容）"""
+    try:
+        with open(RULES_JSON_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+        return {}
+    except Exception as e:
+        logger.error("[bs_plugin_message_filter] 加载规则配置失败: %s", e)
+        return {}
+
+
+def is_rules_enabled() -> bool:
+    """
+    是否启用本插件的所有规则。
+
+    - rules.json 中存在 "enabled": false 时，表示全局禁用该插件
+    - 未配置或解析失败时，默认为禁言用（False）
+    """
+    cfg = _load_raw_config()
+    enabled = cfg.get("enabled", True)
+    return bool(enabled)
+
+
+def _load_rules() -> Dict[str, List[Dict[str, Any]]]:
+    """加载规则内容部分（仅返回各 seg_type 对应的规则列表）"""
+    cfg = _load_raw_config()
+    return {str(k): v for k, v in cfg.items() if isinstance(v, list)}
+
+
+def _save_rules(rules: Dict[str, List[Dict[str, Any]]]) -> None:
+    """保存规则文件"""
+    try:
+        with open(RULES_JSON_PATH, "w", encoding="utf-8") as f:
+            json.dump(rules, f, ensure_ascii=False, indent=2)
+        logger.info("[bs_plugin_message_filter] 规则已保存")
+    except Exception as e:
+        logger.error(f"[bs_plugin_message_filter] 保存规则失败: {e}")
+
+
+def apply_rule(
+    seg: Union[Dict[str, Any], MessageSegment], rule: Dict[str, Any]
+) -> Optional[Union[MessageSegment, Dict[str, Any]]]:
+    """根据规则处理单条消息段"""
+    if isinstance(seg, MessageSegment):
+        seg_type = seg.type
+        data = dict(seg.data)
+    elif isinstance(seg, dict):
+        seg_type = seg.get("type")
+        data = dict(seg.get("data") or {})
+    else:
+        return seg
+
+    mode = rule.get("mode")
+    args = rule.get("args")
+
+    if seg_type == "text":
+        text = str(data.get("text", ""))
+        if mode == "replace" and args:
+            for pair in args:
+                if isinstance(pair, (list, tuple)) and len(pair) == 2:
+                    text = text.replace(str(pair[0]), str(pair[1]))
+        elif mode == "prepend" and args is not None:
+            text = f"{args}{text}"
+        elif mode == "append" and args is not None:
+            text = f"{text}{args}"
+        data["text"] = text
+
+    elif seg_type == "image":
+        if mode == "remove":
+            return None
+        elif mode == "replace_file" and args:
+            data["file"] = args
+        elif mode == "set_summary":
+            data["summary"] = str(args) if args else ""
+        elif mode == "append_summary":
+            data["summary"] = str(data.get("summary", "")) + (str(args) if args else "")
+
+    if isinstance(seg, MessageSegment):
+        seg.data = data
+        return seg
+    return {"type": seg_type, "data": data}
+
+
+def apply_rules_to_message(
+    segments: List[Union[Dict[str, Any], MessageSegment]],
+    *,
+    self_id: Optional[str] = None,
+    user_id: Optional[str] = None,
+    is_bot_message: Optional[bool] = None,
+    debug: bool = False,
+) -> List[Union[MessageSegment, Dict[str, Any]]]:
+    """应用规则到消息段列表
+
+    - 默认只处理机器人自身发送的消息：
+      - 若显式传入 is_bot_message，则直接使用
+      - 否则在同时提供 self_id 和 user_id 时，根据 self_id == user_id 判断
+      - 两者都无法提供时，安全起见默认不处理（返回原始 segments）
+    """
+    if is_bot_message is None:
+        if self_id is not None and user_id is not None:
+            is_bot_message = str(self_id) == str(user_id)
+        else:
+            # 无法判断时，默认认为不是机器人消息，避免误改内容
+            is_bot_message = False
+
+    # 全局开关关闭，或不是机器人自身发送的消息，都直接返回原始消息段
+    if not is_bot_message or not is_rules_enabled():
+        return segments
+
+    rules = _load_rules()
+    if debug:
+        logger.debug(f"[bs_plugin_message_filter] 加载规则: {rules}")
+
+    new_segments: List[Union[MessageSegment, Dict[str, Any]]] = []
+
+    for seg in segments:
+        seg_type = seg.type if isinstance(seg, MessageSegment) else seg.get("type")
+        seg_obj = seg
+
+        if isinstance(seg_type, str) and seg_type in rules:
+            for rule in rules[seg_type]:
+                seg_obj = apply_rule(seg_obj, rule)
+                if debug:
+                    logger.debug(f"[bs_plugin_message_filter] 应用规则到 {seg_type}")
+                if seg_obj is None:
+                    if debug:
+                        logger.debug(f"[bs_plugin_message_filter] 消息段被移除")
+                    break
+
+        if seg_obj is not None:
+            new_segments.append(seg_obj)
+
+    return new_segments
+
+
+class MessageSegmentRulesPlugin:
+    """消息段规则处理插件"""
+
+    def __init__(self, debug: bool = False):
+        self.name = "bs_plugin_message_filter"
+        self.version = "1.0.0"
+        self.debug = debug
+        logger.info(f"[{self.name}] 插件初始化")
+
+    def filter_send_message(
+        self, event_data: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
+        """拦截发送消息并应用规则"""
+        try:
+            action = event_data.get("action")
+            if action not in ["send_msg", "send_private_msg", "send_group_msg"]:
+                return event_data
+
+            params = event_data.get("params", {})
+            message = params.get("message")
+
+            if not message:
+                return event_data
+
+            # 标准化消息格式
+            if isinstance(message, str):
+                segments = [{"type": "text", "data": {"text": message}}]
+            elif isinstance(message, list):
+                segments = message
+            else:
+                return event_data
+
+            # 应用规则
+            new_segments = apply_rules_to_message(
+                segments,
+                self_id=event_data.get("self_id"),
+                is_bot_message=True,
+                debug=self.debug,
+            )
+
+            params["message"] = new_segments
+            event_data["params"] = params
+
+            if self.debug:
+                logger.debug(f"[{self.name}] 原始: {segments}")
+                logger.debug(f"[{self.name}] 处理后: {new_segments}")
+
+            return event_data
+
+        except Exception as e:
+            logger.error(f"[{self.name}] 错误: {e}", exc_info=True)
+            return event_data
+
+    def register(self, processor):
+        """注册过滤器"""
+        from app.server.message_processor import MessageProcessor
+
+        if not isinstance(processor, MessageProcessor):
+            logger.error(f"[{self.name}] processor 类型错误")
+            return
+
+        processor.register_filter(
+            filter_func=self.filter_send_message, direction="send", priority=45
+        )
+        logger.info(f"[{self.name}] 已注册")
+
+
+def setup(processor):
+    """插件入口"""
+    plugin = MessageSegmentRulesPlugin(debug=False)
+    plugin.register(processor)
+    return plugin
+
+
+__all__ = [
+    "setup",
+    "apply_rules_to_message",
+    "apply_rule",
+    "_load_rules",
+    "_save_rules",
+    "RULES_JSON_PATH",
+    "is_rules_enabled",
+]

--- a/app/server/message_processor.py
+++ b/app/server/message_processor.py
@@ -4,153 +4,206 @@
 """
 
 import json
-from typing import Dict, Any, Optional, List, Tuple
-from datetime import datetime
 import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
 
-from ..onebotv11 import EventParser, MessageNormalizer
-from ..onebotv11.models import ApiRequest, Event, MessageEvent, MessageSegmentType, PrivateMessageEvent, GroupMessageEvent, MessageSegment
-from ..onebotv11.message_segment import MessageSegmentParser
 from ..commands.permission_manager import PermissionManager
+from ..onebotv11 import EventParser, MessageNormalizer
+from ..onebotv11.message_segment import MessageSegmentParser
+from ..onebotv11.models import (
+    ApiRequest,
+    Event,
+    GroupMessageEvent,
+    MessageEvent,
+    MessageSegment,
+    MessageSegmentType,
+    PrivateMessageEvent,
+)
 from .filter_manager import FilterManager
+
 
 class MessageProcessor:
     """消息处理器"""
-    
+
     def __init__(self, config_manager, database_manager, logger):
         self.config_manager = config_manager
         self.database_manager = database_manager
         self.logger = logger
-        
+
         # 消息解析器和标准化器
         self.event_parser = EventParser()
         self.message_normalizer = MessageNormalizer()
         self.filter_manager = FilterManager(config_manager, logger)
-    
-    async def preprocess_client_message(self, message_data: Dict[str, Any]) -> Tuple[Optional[Dict[str, Any]], Optional[Event]]:
+
+    async def preprocess_client_message(
+        self, message_data: Dict[str, Any]
+    ) -> Tuple[Optional[Dict[str, Any]], Optional[Event]]:
         """预处理客户端消息"""
         try:
             # 记录原始消息
             self._log_message(message_data, "RECV", "RAW")
-            
+
             # 消息标准化
             normalized_data = await self._normalize_message(message_data)
             if not normalized_data:
                 return None, None
-            
+
             # 解析事件
             event = self.event_parser.parse_event_data(normalized_data)
             if not event and not normalized_data.get("echo"):
                 self.logger.message.debug(f"无法解析事件，已忽略")
                 self.logger.message.debug(f"忽略事件内容：{normalized_data}")
                 return normalized_data, None
-            
+
             # 更新账号活动时间
             if isinstance(event, MessageEvent):
                 await self.config_manager.update_account_last_activity(
                     str(event.self_id), None, "receive"
                 )
-            
+
                 # 消息事件预处理，包括决定是否拦截，应用别名等
-                processed_data = await self._preprocess_message_event(event, normalized_data)
+                processed_data = await self._preprocess_message_event(
+                    event, normalized_data
+                )
                 if not processed_data:
-                    return None, None   
+                    return None, None
                 normalized_data = processed_data
-            
+
             # 记录处理后的消息
             self._log_message(normalized_data, "RECV", "PROCESSED", "debug")
-            
+
             # 重新解析事件，事件也受到预处理的影响，会作用到本体指令集
             event = self.event_parser.parse_event_data(normalized_data)
-            
+
             return normalized_data, event
-            
+
         except Exception as e:
             self.logger.message.error(f"预处理客户端消息失败: {e}")
             return None, None
-    
-    async def postprocess_target_message(self, message_data: Dict[str, Any], self_id: str) -> Optional[Dict[str, Any]]:
+
+    async def postprocess_target_message(
+        self, message_data: Dict[str, Any], self_id: str
+    ) -> Optional[Dict[str, Any]]:
         """后处理目标消息"""
-        try:            
+        try:
             # 记录原始消息
             self._log_message(message_data, "SEND", "RAW")
-            
+
             # 解析事件
             event = self.event_parser.parse_event_data(message_data)
             if event:
                 if isinstance(event, ApiRequest) and "send" in event.action:
-                
+
                     # 消息事件特殊处理
-                    processed_data = await self._postprocess_message_event(event, self_id, message_data)
+                    processed_data = await self._postprocess_message_event(
+                        event, self_id, message_data
+                    )
                     if not processed_data:
                         return None
                     message_data = processed_data
-                    
+
                     # 记录处理后的消息
                     self._log_message(message_data, "SEND", "PROCESSED", "debug")
-            
+
             return message_data
-            
+
         except Exception as e:
             import traceback
+
             traceback.print_exc()
             self.logger.message.error(f"Traceback: {traceback.format_exc()}")
             self.logger.message.error(f"后处理目标消息失败: {e}")
             return None
-    
-    async def _normalize_message(self, message_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    async def _normalize_message(
+        self, message_data: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """标准化消息"""
         global_config = self.config_manager.get_global_config()
         normalization_config = global_config.get("message_normalization", {})
-        
+
         if normalization_config.get("enabled", False):
             return self.message_normalizer.normalize_message_event(
                 message_data,
-                enable_napcat_normalization=normalization_config.get("normalize_napcat_sent", True)
+                enable_napcat_normalization=normalization_config.get(
+                    "normalize_napcat_sent", True
+                ),
             )
-        
+
         return message_data
-    
-    async def _preprocess_message_event(self, event: Event, 
-                                      message_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    async def _preprocess_message_event(
+        self, event: Event, message_data: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """预处理消息事件"""
         # 检查账号是否启用
         is_su = self.config_manager.is_superuser(event.user_id)
-        account_config = await self.config_manager.get_account_config(str(event.self_id))
+        account_config = await self.config_manager.get_account_config(
+            str(event.self_id)
+        )
         if account_config and not account_config.get("enabled", True) and not is_su:
             self.logger.message.info(f"账号 {event.self_id} 已禁用，跳过消息处理")
             return None
-        
+
         # 检查群组是否启用和过期
         if isinstance(event, GroupMessageEvent):
-            group_config = await self.config_manager.get_group_config(str(event.group_id))
-            if group_config and not is_su: # 总是不拦截 su
-                if not group_config.get("enabled", True) and not (event.sender.role in ["owner", "admin"] and event.raw_message.startswith(self.config_manager.get_global_config().get("command_prefix", ""))):
+            group_config = await self.config_manager.get_group_config(
+                str(event.group_id)
+            )
+            if group_config and not is_su:  # 总是不拦截 su
+                if not group_config.get("enabled", True) and not (
+                    event.sender.role in ["owner", "admin"]
+                    and event.raw_message.startswith(
+                        self.config_manager.get_global_config().get(
+                            "command_prefix", ""
+                        )
+                    )
+                ):
                     # 具有管理员权限的成员发送内置命令不受拦截，除非过期
-                    self.logger.message.info(f"群组 {event.group_id} 已禁用，跳过消息处理")
+                    self.logger.message.info(
+                        f"群组 {event.group_id} 已禁用，跳过消息处理"
+                    )
                     return None
-                
+
                 if await self.config_manager.is_group_expired(str(event.group_id)):
-                    self.logger.message.info(f"群组 {event.group_id} 已过期，跳过消息处理")
+                    self.logger.message.info(
+                        f"群组 {event.group_id} 已过期，跳过消息处理"
+                    )
                     return None
 
         # 检查黑名单
         if self._is_in_blacklist(event) and not is_su:
-            self.logger.message.info("消息来自黑名单，跳过处理: user={}, group={}".format(event.user_id, getattr(event, 'group_id', None)))
+            self.logger.message.info(
+                "消息来自黑名单，跳过处理: user={}, group={}".format(
+                    event.user_id, getattr(event, "group_id", None)
+                )
+            )
             return None
-        
+
         # 检查私聊设置
         if isinstance(event, PrivateMessageEvent) and not is_su:
             if not await self._check_private_message_allowed(event):
-                self.logger.message.info(f"私聊消息被拒绝: user={event.user_id}, sub_type={event.sub_type}")
+                self.logger.message.info(
+                    f"私聊消息被拒绝: user={event.user_id}, sub_type={event.sub_type}"
+                )
                 return None
-            
+
         if isinstance(message_data.get("params", {}).get("message"), str):
-            message_data["params"]["message"] = [{"type": "text", "data": {"text": message_data["params"]["message"]}}]
+            message_data["params"]["message"] = [
+                {"type": "text", "data": {"text": message_data["params"]["message"]}}
+            ]
             message_data["message_format"] = "array"
         elif isinstance(message_data.get("params", {}).get("message"), list):
-            message_data["params"]["message"] = [seg if not isinstance(seg, str) else {"type": "text", "data": {"text": seg}} for seg in message_data["params"]["message"]]
-        
+            message_data["params"]["message"] = [
+                (
+                    seg
+                    if not isinstance(seg, str)
+                    else {"type": "text", "data": {"text": seg}}
+                )
+                for seg in message_data["params"]["message"]
+            ]
+
         # 应用多级别名转换，优先级为全局->账号->群组
         message_data = await self.apply_global_aliases(message_data)
         message_data = await self.apply_account_aliases(message_data)
@@ -162,45 +215,67 @@ class MessageProcessor:
             return None
 
         return message_data
-    
-    async def _postprocess_message_event(self, event: Event, self_id: str,
-                                       message_data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+
+    async def _postprocess_message_event(
+        self, event: Event, self_id: str, message_data: Dict[str, Any]
+    ) -> Optional[Dict[str, Any]]:
         """后处理消息事件"""
         if "message" not in message_data.get("params", {}):
-            pass # 无消息内容，跳过处理
+            pass  # 无消息内容，跳过处理
         elif isinstance(message_data.get("params", {}).get("message"), str):
-            message_data["params"]["message"] = [{"type": "text", "data": {"text": message_data["params"]["message"]}}]
+            message_data["params"]["message"] = [
+                {"type": "text", "data": {"text": message_data["params"]["message"]}}
+            ]
             message_data["message_format"] = "array"
         elif isinstance(message_data.get("params", {}).get("message"), list):
-            message_data["params"]["message"] = [seg if not isinstance(seg, str) else {"type": "text", "data": {"text": seg}} for seg in message_data["params"]["message"]]
-            
-        message_data = await self.filter_manager.filter_send_message(event, message_data)
+            message_data["params"]["message"] = [
+                (
+                    seg
+                    if not isinstance(seg, str)
+                    else {"type": "text", "data": {"text": seg}}
+                )
+                for seg in message_data["params"]["message"]
+            ]
+
+        message_data = await self.filter_manager.filter_send_message(
+            event, message_data
+        )
         message_data = await self.decorate_message(event, self_id, message_data)
-                
+
         if not message_data:
             return None
-        
+
         # 更新群组最后消息时间（机器人发送的消息）
         if isinstance(event, ApiRequest) and event.params.get("group_id"):
-            await self.config_manager.update_group_last_message_time(str(event.params.get("group_id")))
-            await self.config_manager.update_account_last_activity(self_id, str(event.params.get("group_id")), "send")
+            await self.config_manager.update_group_last_message_time(
+                str(event.params.get("group_id"))
+            )
+            await self.config_manager.update_account_last_activity(
+                self_id, str(event.params.get("group_id")), "send"
+            )
         else:
-            await self.config_manager.update_account_last_activity(self_id, None, "send")
-        
+            await self.config_manager.update_account_last_activity(
+                self_id, None, "send"
+            )
+
         return message_data
-    
-    async def decorate_message(self, event: Event, self_id: str, message_data: Dict[str, Any]) -> Dict[str, Any]:
+
+    async def decorate_message(
+        self, event: Event, self_id: str, message_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """装饰消息"""
         if not isinstance(event, ApiRequest):
             return message_data
-        
+
         global_config = self.config_manager.get_global_config()
         if not global_config.get("sendcount_notifications", True):
             return message_data
-        
+
         account_config = await self.config_manager.get_account_config(str(self_id))
-        send_info = account_config.get("send_count", {"date": None, "group": {"total": 0}, "private": 0})
-        
+        send_info = account_config.get(
+            "send_count", {"date": None, "group": {"total": 0}, "private": 0}
+        )
+
         decorate_info = None
         if event.params.get("group_id"):
             total_count = send_info["group"]["total"]
@@ -221,61 +296,80 @@ class MessageProcessor:
             if (private_count + 1) % 10 == 0:
                 decorate_info = private_deco_template
 
-        
-        if decorate_info and isinstance(message_data.get("params", {}), dict) and "message" in message_data["params"] and isinstance(message_data["params"]["message"], list):
+        if (
+            decorate_info
+            and isinstance(message_data.get("params", {}), dict)
+            and "message" in message_data["params"]
+            and isinstance(message_data["params"]["message"], list)
+        ):
             existing_types = set()
-            allowed_types = set([MessageSegmentType.AT, MessageSegmentType.TEXT, MessageSegmentType.IMAGE, MessageSegmentType.REPLY])
+            allowed_types = set(
+                [
+                    MessageSegmentType.AT,
+                    MessageSegmentType.TEXT,
+                    MessageSegmentType.IMAGE,
+                    MessageSegmentType.REPLY,
+                ]
+            )
             for seg in message_data["params"]["message"]:
                 existing_types.add(seg["type"])
             if existing_types <= allowed_types:
-                message_data["params"]["message"].append({"type": "text", "data": {"text": decorate_info}})
-        
+                message_data["params"]["message"].append(
+                    {"type": "text", "data": {"text": decorate_info}}
+                )
+
         return message_data
-    
+
     def _is_in_blacklist(self, event: Event) -> bool:
         """检查是否在黑名单中"""
-                
+
         # superuser总是允许
         if self.config_manager.is_superuser(event.user_id):
             return False
-        
+
         # 检查用户黑名单
         if self.config_manager.is_in_blacklist("users", str(event.user_id)):
             return True
-        
+
         # 检查群组黑名单
         if isinstance(event, GroupMessageEvent):
             if self.config_manager.is_in_blacklist("groups", str(event.group_id)):
                 return True
-        
+
         return False
-    
+
     async def _check_private_message_allowed(self, event: PrivateMessageEvent) -> bool:
         """检查私聊消息是否允许"""
         global_config = self.config_manager.get_global_config()
-        
+
         # superuser和人机合一总是允许
         if event.user_id in self.config_manager.get_superuser() + [event.self_id]:
             return True
-        
+
         # 检查是否允许私聊
         if not global_config.get("allow_private", True):
             return False
-        
+
         # 检查是否仅允许好友私聊
         if global_config.get("private_friend_only", True):
             return event.sub_type == "friend"
-        
+
         return True
-    
-    def _log_message(self, message_data: Dict[str, Any], direction: str, stage: str, level: str="info"):
+
+    def _log_message(
+        self,
+        message_data: Dict[str, Any],
+        direction: str,
+        stage: str,
+        level: str = "info",
+    ):
         """记录消息日志"""
         try:
             # 确定消息类型
             post_type = message_data.get("post_type", "unknown")
             message_type = message_data.get("message_type", "")
             action = message_data.get("action", "")
-            
+
             if action:
                 msg_type = f"API_{action}"
             elif post_type == "message" or post_type == "message_sent":
@@ -288,8 +382,8 @@ class MessageProcessor:
                 msg_type = f"REQUEST_{request_type}"
             else:
                 msg_type = post_type.upper()
-                return # 暂时不记录其他类型
-            
+                return  # 暂时不记录其他类型
+
             # 生成内容摘要
             if "params" in message_data:
                 message_data = message_data["params"]
@@ -301,9 +395,13 @@ class MessageProcessor:
                         # 处理字典格式的消息段
                         if isinstance(segment, dict):
                             if segment.get("type") == "text":
-                                text_parts.append(str(segment.get("data", {}).get("text", "")))
+                                text_parts.append(
+                                    str(segment.get("data", {}).get("text", ""))
+                                )
                             elif segment.get("type") == "at":
-                                text_parts.append(f"@{segment.get('data', {}).get('qq', '')}")
+                                text_parts.append(
+                                    f"@{segment.get('data', {}).get('qq', '')}"
+                                )
                             else:
                                 text_parts.append(str(segment)[:1000])
                         # 处理MessageSegment对象
@@ -311,7 +409,9 @@ class MessageProcessor:
                             if segment.type == "text":
                                 text_parts.append(str(segment.data.get("text", "")))
                             elif segment.type == "at":
-                                text_parts.append("@{}".format(segment.data.get('qq', '')))
+                                text_parts.append(
+                                    "@{}".format(segment.data.get("qq", ""))
+                                )
                             else:
                                 text_parts.append(str(segment)[:1000])
                     content_summary = "".join(text_parts)[:100]
@@ -321,119 +421,143 @@ class MessageProcessor:
                 content_summary = message_data["raw_message"][:100]
             else:
                 content_summary = ""
-            
+
             # 额外信息
             extra_info = []
             if "self_id" in message_data:
-                extra_info.append("bot={}".format(message_data['self_id']))
+                extra_info.append("bot={}".format(message_data["self_id"]))
             if "user_id" in message_data:
-                extra_info.append("user={}".format(message_data['user_id']))
+                extra_info.append("user={}".format(message_data["user_id"]))
             if "group_id" in message_data:
-                extra_info.append("group={}".format(message_data['group_id']))
-            
+                extra_info.append("group={}".format(message_data["group_id"]))
+
             extra_str = " ".join(extra_info) if extra_info else ""
-            
+
             # 记录扁平化日志
             self.logger.log_message(
                 direction=f"{direction}_{stage}",
                 message_type=msg_type,
                 content_summary=content_summary,
                 extra_info=extra_str,
-                level=level
+                level=level,
             )
-            
+
         except Exception as e:
             self.logger.message.error(f"记录消息日志失败: {e}")
-    
+
     async def extract_command_info(self, event: Event) -> Optional[Dict[str, Any]]:
         """提取指令信息"""
         if not isinstance(event, (PrivateMessageEvent, GroupMessageEvent)):
             return None
-        
+
         global_config = self.config_manager.get_global_config()
         command_prefix = global_config.get("command_prefix", "bs")
-        
+
         return self.message_normalizer.extract_command_info(event, command_prefix)
-    
-    async def _apply_aliases(self, message_data: Dict[str, Any], aliases: Dict[str, List[str]]) -> Dict[str, Any]:
-        # 处理消息段
+
+    async def _apply_aliases(
+        self, message_data: Dict[str, Any], aliases: Dict[str, List[str]]
+    ) -> Dict[str, Any]:
+        # 处理消息段（直接使用标准的 message 字段）
+        segments = message_data.get("message")
+        if not segments or not isinstance(segments, list):
+            return message_data
+
         modified = False
-        for sid, segment in enumerate(message_data["message"]):
+        for sid, segment in enumerate(segments):
             if segment.get("type") == "text":
                 text = segment.get("data", {}).get("text", "")
                 # 检查是否匹配别名
                 for target, alias_list in aliases.items():
-                    if text.startswith(target) and target not in alias_list: # 旁路原名
-                        message_data["message"][sid]["data"]["text"] = uuid.uuid4().hex + text[len(target):] # 我讨厌yunzai
+                    if text.startswith(target) and target not in alias_list:  # 旁路原名
+                        segment["data"]["text"] = (
+                            uuid.uuid4().hex + text[len(target) :]
+                        )  # 我讨厌yunzai
                         # message_data["message"][sid]["data"]["text"] = text[len(target):] # 为了支持取消前缀
                         modified = True
                         break
                     for alias in alias_list:
                         if text.startswith(alias):
                             # 替换别名
-                            new_text = target + text[len(alias):]
-                            message_data["message"][sid]["data"]["text"] = new_text
+                            new_text = target + text[len(alias) :]
+                            segments[sid]["data"]["text"] = new_text
                             modified = True
                             break
                     if modified:
                         break
-                break # 只替换第一个字符部分，毕竟叫做指令别名
-        
+                break  # 只替换第一个字符部分，毕竟叫做指令别名
+
         # 更新raw_message
         if modified and "raw_message" in message_data:
             # 重新生成raw_message
-            message_data["raw_message"] = MessageSegmentParser.message2raw_message(message_data["message"])
-            
+            message_data["raw_message"] = MessageSegmentParser.message2raw_message(
+                segments
+            )
+
         return message_data
-    
-    async def apply_global_aliases(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
+
+    async def apply_global_aliases(
+        self, message_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         """应用全局别名"""
         try:
-            if "message" not in message_data or not isinstance(message_data["message"], list):
+            if "message" not in message_data or not isinstance(
+                message_data["message"], list
+            ):
                 return message_data
-            
+
             global_config = self.config_manager.get_global_config()
             aliases = global_config.get("global_aliases", {})
-            
+
             if not aliases:
                 return message_data
-            
+
             return await self._apply_aliases(message_data, aliases)
-            
+
         except Exception as e:
             self.logger.message.error(f"应用全局别名失败: {e}")
             return message_data
 
-    async def apply_account_aliases(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
+    async def apply_account_aliases(
+        self, message_data: Dict[str, Any]
+    ) -> Dict[str, Any]:
         try:
-            if "message" not in message_data or not isinstance(message_data["message"], list):
+            if "message" not in message_data or not isinstance(
+                message_data["message"], list
+            ):
                 return message_data
-            
-            account_config = await self.config_manager.get_account_config(str(message_data["self_id"]))
+
+            account_config = await self.config_manager.get_account_config(
+                str(message_data["self_id"])
+            )
             aliases = account_config.get("aliases", {})
-            
+
             if not aliases:
                 return message_data
-            
+
             return await self._apply_aliases(message_data, aliases)
-            
+
         except Exception as e:
             self.logger.message.error(f"应用账号别名失败: {e}")
             return message_data
-    
+
     async def apply_group_aliases(self, message_data: Dict[str, Any]) -> Dict[str, Any]:
         try:
-            if "message" not in message_data or not isinstance(message_data["message"], list):
+            if "message" not in message_data or not isinstance(
+                message_data["message"], list
+            ):
                 return message_data
-            
-            group_config = await self.config_manager.get_group_config(str(message_data["group_id"]))
+
+            group_config = await self.config_manager.get_group_config(
+                str(message_data["group_id"])
+            )
             aliases = group_config.get("aliases", {})
-            
+
             if not aliases:
                 return message_data
-            
+
             return await self._apply_aliases(message_data, aliases)
-            
+
         except Exception as e:
             self.logger.message.error(f"应用群组别名失败: {e}，{message_data}")
             return message_data


### PR DESCRIPTION
运行一次框架后会得到一个原始json文件

```json
{
  "enabled": false
}
```

## Json结构示例

```json
{
  "enabled": true, 

  "text": [
    {
      "mode": "replace",
      "args": [
        ["原词", "新词"],
        ["坏话", "***"]
      ]
    },
    {
      "mode": "prepend",
      "args": "【前缀】"
    },
    {
      "mode": "append",
      "args": "【后缀】"
    }
  ],

  "image": [
    {
      "mode": "set_summary",
      "args": "这是一张图片"
    },
    {
      "mode": "append_summary",
      "args": "（已处理）"
    },
    {
      "mode": "replace_file",
      "args": "file:///C:/xxx/xxx.png"
    },
    {
      "mode": "remove"
    }
  ]
}
```

enabled: 插件启停开关
第一层是OneBot消息类型
第二层是具体操作
第三层是操作参数

---

## 测试

![111](https://gitee.com/Elvin-Apocalys/pic-bed/raw/master/git_img/gitpng.png)

## 增减操作或获取OneBot消息体另谋他路

在**plugin.py**第192行到第200行间，`segments`变量是捕获到的原始消息体，`new_segments`是处理过的消息体